### PR TITLE
fix fetch-devcontainer error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   "containerEnv": {
     "PROJECT_DIR": "/project"
   },
-  "postAttachCommand": "bash -c 'devtools setup-devcontainer && devtools setup-keypair'",
+  "postAttachCommand": "cd /project && bash -c 'devtools setup-devcontainer && devtools setup-keypair'",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
The error is because when we curl, we only get the .devcontainer.json file and the mounting doesn't work as expected. We need to cd into the /project directory.